### PR TITLE
Relax some version dependencies.

### DIFF
--- a/text-compression.cabal
+++ b/text-compression.cabal
@@ -1,4 +1,4 @@
-cabal-version:      3.0
+cabal-version:      2.4
 -- The cabal-version field refers to the version of the .cabal specification,
 -- and can be different from the cabal-install (the tool) version and the
 -- Cabal (the library) version you are using. As such, the Cabal (the library)
@@ -80,12 +80,12 @@ library
     -- other-extensions:
 
     -- Other library packages from which modules are imported.
-    build-depends:    base       ^>=4.16.3.0,
-                      bytestring >= 0.11.3 && < 0.12,
-                      containers >= 0.6.5 && < 0.7,
+    build-depends:    base       ^>=4.12.0.0,
+                      bytestring >= 0.10.8.2 && < 0.12,
+                      containers >= 0.6.0.1 && < 0.7,
                       mtl        >= 2.2.2 && < 2.3,
                       parallel   >= 3.2.2 && < 3.3,
-                      text       >= 1.2.5 && < 1.3
+                      text       >= 1.2.3.1 && < 1.3
 
     -- Directories containing source files.
     hs-source-dirs:   src


### PR DESCRIPTION
These dependencies are old enough to build with ghcjs-8.6.0.1.  This should not affect building with newer versions.